### PR TITLE
fix: update upload-artifact action version from v3 to v4

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -42,7 +42,7 @@ jobs:
         fi
 
     - name: Upload coverage to GitHub
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coverage.xml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Upload package artifact
       if: success()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: markdown-inspector-package
         path: dist/


### PR DESCRIPTION
Update GitHub Actions upload-artifact references to address Missing